### PR TITLE
Remove excess arrayref wrapping of lua proc args

### DIFF
--- a/lib/DR/Tarantool/MsgPack/LLClient.pm
+++ b/lib/DR/Tarantool/MsgPack/LLClient.pm
@@ -158,7 +158,7 @@ sub call_lua {
     }
 
     my $id = $self->_req_id;
-    my $pkt = DR::Tarantool::MsgPack::Proto::call_lua($id, $proc, $tuple);
+    my $pkt = DR::Tarantool::MsgPack::Proto::_call_lua($id, $proc, $tuple);
     $self->_request($id, $pkt, $cb);
     return;
 }

--- a/msgpack.c
+++ b/msgpack.c
@@ -111,7 +111,9 @@ void _mpack_item(SV *res, SV *o)
 		case SVt_PVIV:
 		case SVt_PVNV:
 		case SVt_PVMG:
+#if PERL_VERSION >= 11
 		case SVt_REGEXP:
+#endif
 			if (!looks_like_number(o)) {
 				s = SvPV(o, len);
 				new_len = res_len + mp_sizeof_str(len);


### PR DESCRIPTION
Method call_lua() expects array of args but we already have arrayref in LLClient, so we need to use _call_lua().