### PR TITLE
Remove excess arrayref wrapping of lua proc args

### DIFF
--- a/lib/DR/Tarantool/MsgPack/LLClient.pm
+++ b/lib/DR/Tarantool/MsgPack/LLClient.pm
@@ -158,7 +158,7 @@ sub call_lua {
     }
 
     my $id = $self->_req_id;
-    my $pkt = DR::Tarantool::MsgPack::Proto::call_lua($id, $proc, $tuple);
+    my $pkt = DR::Tarantool::MsgPack::Proto::_call_lua($id, $proc, $tuple);
     $self->_request($id, $pkt, $cb);
     return;
 }


### PR DESCRIPTION
Method call_lua() expects array of args but we already have arrayref in LLClient, so we need to use _call_lua().
